### PR TITLE
fix: add content disposition parameter with filename

### DIFF
--- a/src/backend/service/document_management/document_management.py
+++ b/src/backend/service/document_management/document_management.py
@@ -64,7 +64,7 @@ def get_all_files(
     for document in site_specific_documents:
         presigned_get_url = None
         if document.document_type == FileType.FILE.value:
-            presigned_get_url = bucket.create_get_url(document.s3_key)
+            presigned_get_url = bucket.create_get_url(document.s3_key, document.document_name)
         api_document = document.to_api_model(presigned_get_url)
         returned_documents.append(api_document)
 

--- a/src/backend/service/file_storage/s3_bucket.py
+++ b/src/backend/service/file_storage/s3_bucket.py
@@ -61,7 +61,12 @@ class S3Bucket:
         :return: The get object presigned url
         """
         return self._client.generate_presigned_url(
-            ClientMethod="get_object", Params={"Bucket": self.name, "Key": key, "ResponseContentDisposition": f'attachment; filename="{original_filename}"'}
+            ClientMethod="get_object",
+            Params={
+                "Bucket": self.name,
+                "Key": key,
+                "ResponseContentDisposition": f'attachment; filename="{original_filename}"',
+            },
         )
 
     def delete(self, key: str, e_tag: Optional[str] = None) -> None:

--- a/src/backend/service/file_storage/s3_bucket.py
+++ b/src/backend/service/file_storage/s3_bucket.py
@@ -58,6 +58,7 @@ class S3Bucket:
         Creates a presigned get url to get an object from S3
 
         :param key: The key of the object to get from S3
+        :param original_filename: The name of the file to be downloaded
         :return: The get object presigned url
         """
         return self._client.generate_presigned_url(

--- a/src/backend/service/file_storage/s3_bucket.py
+++ b/src/backend/service/file_storage/s3_bucket.py
@@ -53,7 +53,7 @@ class S3Bucket:
             raise PermissionException("Creating an upload URL requires write access")
         return self._client.generate_presigned_post(Bucket=self.name, Key=key, Fields={})
 
-    def create_get_url(self, key: str) -> str:
+    def create_get_url(self, key: str, original_filename: str) -> str:
         """
         Creates a presigned get url to get an object from S3
 
@@ -61,7 +61,7 @@ class S3Bucket:
         :return: The get object presigned url
         """
         return self._client.generate_presigned_url(
-            ClientMethod="get_object", Params={"Bucket": self.name, "Key": key}
+            ClientMethod="get_object", Params={"Bucket": self.name, "Key": key, "ResponseContentDisposition": f'attachment; filename="{original_filename}"'}
         )
 
     def delete(self, key: str, e_tag: Optional[str] = None) -> None:

--- a/src/backend/service/models/db/site_visit.py
+++ b/src/backend/service/models/db/site_visit.py
@@ -55,7 +55,7 @@ class DBSiteVisit(DBItemModel):
         # pylint: disable=no-member
         for name, s3_key in self.attachments.items():
             attachments.append(
-                APIFileAttachmentResponse(name=name, url=bucket.create_get_url(key=s3_key))
+                APIFileAttachmentResponse(name=name, url=bucket.create_get_url(key=s3_key, original_filename=name))
             )
         return APISiteVisit(
             site_id=self.site_id,

--- a/src/backend/service/models/db/site_visit.py
+++ b/src/backend/service/models/db/site_visit.py
@@ -55,7 +55,9 @@ class DBSiteVisit(DBItemModel):
         # pylint: disable=no-member
         for name, s3_key in self.attachments.items():
             attachments.append(
-                APIFileAttachmentResponse(name=name, url=bucket.create_get_url(key=s3_key, original_filename=name))
+                APIFileAttachmentResponse(
+                    name=name, url=bucket.create_get_url(key=s3_key, original_filename=name)
+                )
             )
         return APISiteVisit(
             site_id=self.site_id,

--- a/test/backend/unit/file_storage/test_s3_bucket.py
+++ b/test/backend/unit/file_storage/test_s3_bucket.py
@@ -14,7 +14,7 @@ from backend.service.util import AWSAccessLevel
 from botocore.exceptions import ClientError
 from botocore.stub import Stubber
 
-from ..constants import TEST_S3_FILE_CONTENT, TEST_S3_FILE_KEY
+from ..constants import TEST_ATTACHMENT_NAME, TEST_S3_FILE_CONTENT, TEST_S3_FILE_KEY
 
 
 def test_upload_file(empty_s3_bucket):
@@ -55,7 +55,7 @@ def test_get_object_url(s3_bucket_with_item):
     bucket = S3Bucket(bucket_name=DOCUMENT_STORAGE_BUCKET_NAME, access=AWSAccessLevel.READ)
 
     # Create get url
-    url = bucket.create_get_url(key=TEST_S3_FILE_KEY)
+    url = bucket.create_get_url(key=TEST_S3_FILE_KEY, original_filename=TEST_ATTACHMENT_NAME)
 
     # Get content from URL
     http_response = requests.get(url=url)


### PR DESCRIPTION
This is needed as we are now using the document uuid as the s3 key. Without this field, files are downloaded with the filename as the uuid instead of its actual name
Resolves #534 