### PR TITLE
docs(rev1): add swagger ui path in api

### DIFF
--- a/src/backend/service/handler.py
+++ b/src/backend/service/handler.py
@@ -21,6 +21,7 @@ from .util import CORS_HEADERS
 
 logger = Logger()
 app = APIGatewayRestResolver(enable_validation=True)
+app.enable_swagger(path="/unprotected/swagger")
 app.include_router(router=site_visits.router, prefix="/protected/site")
 app.include_router(router=site.router, prefix="/protected/site-management")
 app.include_router(router=users.router, prefix="/protected/users")


### PR DESCRIPTION
Just creates the path, and describes parameters (because we've been using the openapi thing for parameters thankfully) need to add things like security schemas, cors headers, and various response details